### PR TITLE
always set performers when creating scheduled show

### DIFF
--- a/app/models/scheduled_show.rb
+++ b/app/models/scheduled_show.rb
@@ -20,7 +20,7 @@ class ScheduledShow < ActiveRecord::Base
   has_many :performers, through: :scheduled_show_performers, source: :user
   accepts_nested_attributes_for :scheduled_show_performers
 
-  validates_presence_of :start_at, :end_at, :playlist_id, :title
+  validates_presence_of :start_at, :end_at, :playlist_id, :title, :dj_id
   validates :description, length: { maximum: 10000 }
 
   validate :start_at_cannot_be_in_the_past, on: :create
@@ -170,7 +170,7 @@ class ScheduledShow < ActiveRecord::Base
   private
 
   def add_performers
-    if self.performers.empty?
+    if self.scheduled_show_performers.empty?
       self.performers << self.dj
     end
   end

--- a/app/models/scheduled_show.rb
+++ b/app/models/scheduled_show.rb
@@ -38,7 +38,7 @@ class ScheduledShow < ActiveRecord::Base
   before_destroy :maybe_destroy_recurrences
 
   before_save :ensure_time_zone
-
+  before_save :add_performers
 
   enum recurring_interval: [:not_recurring, :day, :week, :month, :year, :biweek]
 
@@ -168,6 +168,13 @@ class ScheduledShow < ActiveRecord::Base
   end
 
   private
+
+  def add_performers
+    if self.performers.empty?
+      self.performers << self.dj
+    end
+  end
+
   def recurring_interval_changed?
     self.changes.has_key? "recurring_interval"
   end

--- a/app/serializers/dj_serializer.rb
+++ b/app/serializers/dj_serializer.rb
@@ -1,5 +1,6 @@
 class DjSerializer < ActiveModel::Serializer
-  attributes :id, :username, :image_url, :bio, :image_thumb_url, :image_medium_url, :profile_publish
+  attributes :id, :username, :image_url, :bio, :image, :image_filename,
+    :image_thumb_url, :image_medium_url, :profile_publish
 
   def image_url
     if object.image.present?

--- a/script/fix_repeating_shows.rb
+++ b/script/fix_repeating_shows.rb
@@ -1,0 +1,10 @@
+show_id = ARGV[1]
+s = ScheduledShow.find(show_id)
+original = s.recurrant_original
+
+original.recurrences.find_each do |show|
+  if show.performers.empty?
+    show.performers << show.dj
+  end
+  show.save!
+end

--- a/spec/models/scheduled_show_spec.rb
+++ b/spec/models/scheduled_show_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe ScheduledShow, :type => :model do
     @date = Date.today.strftime("%m%d%Y")
   end
 
+  describe "performers" do
+    it "sets the DJ as the performer if no performers are specified" do
+      @scheduled_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: @start_at, end_at: @end_at, title: "hey hey", dj: @dj
+      expect(@scheduled_show.performers).to include(@dj)
+    end
+  end
+
   describe "slugs" do
     it "saves the unique slug with title and id" do
       start_at = Chronic.parse("today at 3:15 pm").utc
@@ -70,19 +77,22 @@ RSpec.describe ScheduledShow, :type => :model do
     it "saves recurring shows if recurring is true" do
       start_at = Chronic.parse("today at 1:15 pm").utc
       end_at = Chronic.parse("today at 3:15 pm").utc
-      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey"
+      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey", dj: @dj
       expect(ScheduledShow.where("start_at >= (?) AND start_at <= (?)", start_at.beginning_of_month, start_at.end_of_month).count).to eq 1
       expect(recurring_show.recurrences.count).to eq 275
+      # it copies the performers over
+      expect(recurring_show.recurrences.map {|m| m.performers.count }.uniq).to eq [1]
 
       start_at = Chronic.parse("today at 3:15 pm").utc
       end_at = Chronic.parse("today at 5:15 pm").utc
-      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "week", title: "hey weekly edition"
+      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "week", title: "hey weekly edition", dj: @dj
       expect(ScheduledShow.where(start_at: start_at).count).to eq 1
 
       start_at = Chronic.parse("today at 3:15 pm").utc
       end_at = Chronic.parse("today at 5:15 pm").utc
-      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "biweek", title: "hey weekly edition"
+      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "biweek", title: "hey weekly edition", dj: @dj
       expect(recurring_show.recurrences.count).to eq 600
+      expect(recurring_show.recurrences.map {|m| m.performers.count }.uniq).to eq [1]
     end
 
     it "creates a unique slug for each recurrence" do

--- a/spec/models/scheduled_show_spec.rb
+++ b/spec/models/scheduled_show_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe ScheduledShow, :type => :model do
     it "sets the DJ as the performer if no performers are specified" do
       @scheduled_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: @start_at, end_at: @end_at, title: "hey hey", dj: @dj
       expect(@scheduled_show.performers).to include(@dj)
+      expect(@scheduled_show.performers.count).to eq 1
+    end
+
+    it "doesnt save extra performers" do
+      @scheduled_show = ScheduledShow.create radio: @radio,
+        playlist: @playlist, start_at: @start_at, end_at: @end_at, title: "hey hey",
+        dj: @dj,
+        scheduled_show_performers_attributes: { "0": { user_id: @dj.id } }
+      expect(@scheduled_show.performers).to include(@dj)
+      expect(@scheduled_show.performers.count).to eq 1
     end
   end
 
@@ -24,7 +34,7 @@ RSpec.describe ScheduledShow, :type => :model do
     it "saves the unique slug with title and id" do
       start_at = Chronic.parse("today at 3:15 pm").utc
       end_at = Chronic.parse("today at 5:15 pm").utc
-      @scheduled_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, title: "hey hey"
+      @scheduled_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, title: "hey hey", dj: @dj
       expect(@scheduled_show.slug).to eq "hey-hey"
     end
   end
@@ -37,7 +47,7 @@ RSpec.describe ScheduledShow, :type => :model do
           end_at = Time.zone.parse("2090-02-01 11:00")
 
           time_zone = "Eastern Time (US & Canada)"
-          @scheduled_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, time_zone: time_zone, title: "my show with dj steve martin"
+          @scheduled_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, time_zone: time_zone, title: "my show with dj steve martin", dj: @dj
 
           format = "%a, %d %b %Y %H:%M:%S"
           expect(@scheduled_show.start_at).to eq start_at.strftime(format).in_time_zone(time_zone)
@@ -51,7 +61,7 @@ RSpec.describe ScheduledShow, :type => :model do
     it "start time cannot be in the past" do
       start_at = Chronic.parse("yesterday at 3:15 pm").utc
       end_at = Chronic.parse("today at 2:15 pm").utc
-      @scheduled_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, title: "hey"
+      @scheduled_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, title: "hey", dj: @dj
       expect(@scheduled_show.errors[:start_at]).to be_present
     end
     it "end time cannot be in the past" do
@@ -63,7 +73,7 @@ RSpec.describe ScheduledShow, :type => :model do
     it "end time cannot be before start time" do
       start_at = Chronic.parse("today at 3:15 pm").utc
       end_at = Chronic.parse("today at 2:15 pm").utc
-      @scheduled_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, title: "hey"
+      @scheduled_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, title: "hey", dj: @dj
       expect(@scheduled_show.errors[:end_at]).to be_present
     end
   end
@@ -98,7 +108,7 @@ RSpec.describe ScheduledShow, :type => :model do
     it "creates a unique slug for each recurrence" do
       start_at = Chronic.parse("today at 1:15 pm").utc
       end_at = Chronic.parse("today at 3:15 pm").utc
-      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey"
+      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey", dj: @dj
       expect(ScheduledShow.where("start_at >= (?) AND start_at <= (?)", start_at.beginning_of_month, start_at.end_of_month).count).to eq 1
       count = recurring_show.recurrences.count
       expect(count).to eq 275
@@ -108,7 +118,7 @@ RSpec.describe ScheduledShow, :type => :model do
     it "doesnt duplicate slugs on update" do
       start_at = Chronic.parse("today at 1:15 pm").utc
       end_at = Chronic.parse("today at 3:15 pm").utc
-      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey"
+      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey", dj: @dj
       new_start_at = Chronic.parse("today at 11:00 am").utc
       recurring_show.update start_at: new_start_at, update_all_recurrences: true
 
@@ -120,7 +130,7 @@ RSpec.describe ScheduledShow, :type => :model do
     it "updates all recurring shows attributes" do
       start_at = Chronic.parse("today at 1:15 pm").utc
       end_at = Chronic.parse("today at 3:15 pm").utc
-      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey"
+      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey", dj: @dj
       new_start_at = Chronic.parse("today at 11:00 am").utc
       recurring_show.update start_at: new_start_at, update_all_recurrences: true
       recurring_show.recurrences.each do |recurrence|
@@ -133,7 +143,7 @@ RSpec.describe ScheduledShow, :type => :model do
     it "updates this recurrance only" do
       start_at = Chronic.parse("today at 1:15 pm").utc
       end_at = Chronic.parse("today at 3:15 pm").utc
-      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "week", title: "hey"
+      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "week", title: "hey", dj: @dj
       new_start_at = Chronic.parse("today at 11:00 am").utc
       recurring_show.update start_at: new_start_at, update_all_recurrences: false
       recurring_show.recurrences.each do |recurrence|
@@ -146,7 +156,7 @@ RSpec.describe ScheduledShow, :type => :model do
     it "updates all recurring shows with a new recurrence" do
       start_at = Chronic.parse("today at 1:15 pm").utc
       end_at = Chronic.parse("today at 3:15 pm").utc
-      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "week", title: "hey"
+      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "week", title: "hey", dj: @dj
       expect(recurring_show.recurrences.count).to eq 1200
       recurring_show.update recurring_interval: "month"
       expect(recurring_show.recurrences.count).to eq 275
@@ -155,7 +165,7 @@ RSpec.describe ScheduledShow, :type => :model do
     it "deletes all recurring shows if destroy_recurrences is set" do
       start_at = Chronic.parse("today at 1:15 pm").utc
       end_at = Chronic.parse("today at 3:15 pm").utc
-      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey"
+      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey", dj: @dj
       recurring_show.destroy_recurrences = true
       recurring_show.destroy
       expect(recurring_show.recurrences.count).to eq 0
@@ -164,7 +174,7 @@ RSpec.describe ScheduledShow, :type => :model do
     it "doesn't delete all recurring shows if destroy_recurrences is not set" do
       start_at = Chronic.parse("today at 1:15 pm").utc
       end_at = Chronic.parse("today at 3:15 pm").utc
-      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey"
+      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey", dj: @dj
       recurring_show.destroy
       expect(recurring_show.recurrences.count).to eq 275
     end
@@ -172,7 +182,7 @@ RSpec.describe ScheduledShow, :type => :model do
     it "only deletes recurring shows in the future" do
       start_at = Chronic.parse("today at 1:15 pm").utc
       end_at = Chronic.parse("today at 3:15 pm").utc
-      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey"
+      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey", dj: @dj
       Timecop.travel 6.months.from_now do
         recurring_show.destroy_recurrences = true
         recurring_show.destroy
@@ -185,7 +195,7 @@ RSpec.describe ScheduledShow, :type => :model do
     it "updates all recurrences +1 hour for DST" do
       start_at = Chronic.parse("today at 1:15 pm").utc
       end_at = Chronic.parse("today at 3:15 pm").utc
-      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey"
+      recurring_show = ScheduledShow.create radio: @radio, playlist: @playlist, start_at: start_at, end_at: end_at, recurring_interval: "month", title: "hey", dj: @dj
       recurring_show.recurrences.each do |r|
         expect(r.start_at).to eq start_at
         expect(r.end_at).to eq end_at


### PR DESCRIPTION
This should fix the issue trash panda mentioned:
```
Trash Panda QCToday at 7:33 AM
I might have bugged you before about this but is there a way to update which podcasts appear on my dj page?  it seems like they stopped in August

```

I need to run a script to update existing data however.