### PR TITLE
don't return scheduled_show track in serializer if the show is not archived yet

### DIFF
--- a/app/serializers/scheduled_show_serializer.rb
+++ b/app/serializers/scheduled_show_serializer.rb
@@ -13,7 +13,10 @@ class ScheduledShowSerializer < ActiveModel::Serializer
   end
 
   def tracks
-    object.tracks
+    # don't show tracks if the show isn't over yet...
+    if Time.now > object.end
+      object.tracks
+    end
   end
 
   def html_description

--- a/app/serializers/scheduled_show_serializer.rb
+++ b/app/serializers/scheduled_show_serializer.rb
@@ -20,8 +20,10 @@ class ScheduledShowSerializer < ActiveModel::Serializer
 
   def tracks
     # don't show tracks if the show isn't over yet...
-    if Time.now > object.end
-      object.tracks
+    if Time.now > object.end_at
+      return object.tracks
+    else
+      return []
     end
   end
 


### PR DESCRIPTION
This will prevent the track being show on the public show page on datafruits, if the show is not finished broadcasting yet.