### PR TITLE
Make liquidsoap requests not a singleton

### DIFF
--- a/app/controllers/liquidsoap_requests_controller.rb
+++ b/app/controllers/liquidsoap_requests_controller.rb
@@ -1,7 +1,8 @@
 class LiquidsoapRequestsController < ApplicationController
   before_action :current_radio_required
   def index
-    @requests = LiquidsoapRequests.alive @current_radio
-    @on_air = LiquidsoapRequests.on_air @current_radio
+    @liquidsoap = LiquidsoapRequests.new @current_radio.id
+    @requests = @liquidsoap.alive
+    @on_air = @liquidsoap.on_air
   end
 end

--- a/app/services/liquidsoap_requests.rb
+++ b/app/services/liquidsoap_requests.rb
@@ -6,7 +6,7 @@ class LiquidsoapRequests
 
   def self.on_air radio, liquidsoap_socket_class=Liquidsoap::Socket
     liquidsoap_socket = liquidsoap_socket_class.new(radio.liquidsoap_socket_path)
-    liquidsoap_socket.write("request.on_air").gsub(/END/, "").split(" ").first
+    liquidsoap_socket.write("request.on_air").gsub(/END/, "")
   end
 
   def self.metadata radio, rid, liquidsoap_socket_class=Liquidsoap::Socket

--- a/app/services/liquidsoap_requests.rb
+++ b/app/services/liquidsoap_requests.rb
@@ -1,35 +1,35 @@
 class LiquidsoapRequests
-  def self.alive radio, liquidsoap_socket_class=Liquidsoap::Socket
-    liquidsoap_socket = liquidsoap_socket_class.new(radio.liquidsoap_socket_path)
-    liquidsoap_socket.write("request.alive").gsub(/END/, "").split(" ")
+  def initialize radio_id, liquidsoap_socket_class=Liquidsoap::Socket
+    @radio = Radio.find radio_id
+    @liquidsoap_socket = liquidsoap_socket_class.new(@radio.liquidsoap_socket_path)
   end
 
-  def self.on_air radio, liquidsoap_socket_class=Liquidsoap::Socket
-    liquidsoap_socket = liquidsoap_socket_class.new(radio.liquidsoap_socket_path)
-    liquidsoap_socket.write("request.on_air").gsub(/END/, "")
+  def alive
+    @liquidsoap_socket.write("request.alive").gsub(/END/, "").split(" ")
   end
 
-  def self.metadata radio, rid, liquidsoap_socket_class=Liquidsoap::Socket
-    liquidsoap_socket = liquidsoap_socket_class.new(radio.liquidsoap_socket_path)
-    liquidsoap_socket.write("request.metadata #{rid}").force_encoding("UTF-8")
+  def on_air
+    @liquidsoap_socket.write("request.on_air").gsub(/END/, "").split(" ")
   end
 
-  def self.on_air_filename radio
-    on_air_rid = self.on_air radio
-    metadata_line = self.metadata radio, on_air_rid
-    metadata_line.split("\n")
-    uri_line = metadata_line.split("\n").select{ |m| m.include?("initial_uri")}.first
-    return uri_line.split(",").select{ |m| m.include?("http") }.first.split(":").last(2).join(":")
+  def metadata rid
+    @liquidsoap_socket.write("request.metadata #{rid}").force_encoding("UTF-8")
   end
 
-  def self.add_to_queue radio_id, uri, liquidsoap_socket_class=Liquidsoap::Socket
-    radio = Radio.find radio_id
-    liquidsoap_socket = liquidsoap_socket_class.new(radio.liquidsoap_socket_path)
-    liquidsoap_socket.write("scheduled_shows.push #{uri}").encode("UTF-8")
+  # TODO
+  # def on_air_filename
+  #   on_air_rid = on_air radio
+  #   metadata_line = metadata on_air_rid
+  #   metadata_line.split("\n")
+  #   uri_line = metadata_line.split("\n").select{ |m| m.include?("initial_uri")}.first
+  #   return uri_line.split(",").select{ |m| m.include?("http") }.first.split(":").last(2).join(":")
+  # end
+
+  def add_to_queue uri
+    @liquidsoap_socket.write("scheduled_shows.push #{uri}").encode("UTF-8")
   end
 
-  def self.skip radio, liquidsoap_socket_class=Liquidsoap::Socket
-    liquidsoap_socket = liquidsoap_socket_class.new(radio.liquidsoap_socket_path)
-    liquidsoap_socket.write("icecast.1.skip").encode("UTF-8")
+  def skip
+    @liquidsoap_socket.write("icecast.1.skip").encode("UTF-8")
   end
 end

--- a/app/services/schedule_monitor.rb
+++ b/app/services/schedule_monitor.rb
@@ -19,7 +19,8 @@ class ScheduleMonitor
       # if previous show is set to no_cue_out, or previous show is blank, time to skip!
       if current_playing_show_in_redis.blank? || !current_playing_show_in_redis.playlist.no_cue_out? # check cue out of previous show
         puts "skipping"
-        LiquidsoapRequests.skip radio
+        liquidsoap = LiquidsoapRequests.new radio.id
+        liquidsoap.skip
       end
       # current_scheduled_show_in_db and redis should sync
       radio.set_current_show_playing current_scheduled_show_in_db.id

--- a/app/services/skip_track.rb
+++ b/app/services/skip_track.rb
@@ -1,6 +1,7 @@
 class SkipTrack
-  def self.perform radio, liquidsoap_socket_class=Liquidsoap::Socket
-    liquidsoap_socket = liquidsoap_socket_class.new(radio.liquidsoap_socket_path)
-    liquidsoap_socket.write "icecast.1.skip"
+  def self.perform radio
+    liquidsoap = LiquidsoapRequests.new radio.id
+    liquidsoap.skip
+    ScheduleMonitor.perform radio, Time.now
   end
 end

--- a/app/views/liquidsoap_requests/index.html.erb
+++ b/app/views/liquidsoap_requests/index.html.erb
@@ -3,9 +3,9 @@
     <% @requests.each do |request| %>
       <tr>
         <td><strong>Request ID:</strong> <%= request %></td>
-        <td><%= LiquidsoapRequests.metadata @current_radio, request %></td>
+        <td><%= @liquidsoap.metadata request %></td>
       </tr>
     <% end %>
   </tbody>
 </table>
-<strong>On air request:</strong> <%= @on_air %>
+<strong>On air requests:</strong> <%= @on_air.to_s %>

--- a/spec/services/schedule_monitor_spec.rb
+++ b/spec/services/schedule_monitor_spec.rb
@@ -8,7 +8,8 @@ describe ScheduleMonitor do
   let(:playlist) { FactoryBot.create :playlist, radio: radio }
   let(:show){ FactoryBot.create :scheduled_show }
   let(:dj){ FactoryBot.create :user }
-  let(:liquidsoap_requests) { class_double("LiquidsoapRequests").as_stubbed_const }
+  let(:liquidsoap_requests_class) { class_double("LiquidsoapRequests").as_stubbed_const }
+  let(:liquidsoap) { instance_double("LiquidsoapRequests") }
 
   it "sets current show playing in redis to nil if there is no scheduled show in the db" do
     ScheduleMonitor.perform radio, Time.now
@@ -20,8 +21,8 @@ describe ScheduleMonitor do
         start_at: Chronic.parse("January 1st 2090 at 10:30 pm"), end_at: Chronic.parse("January 2nd 2090 at 01:30 am"),
         dj: dj
       Timecop.travel Chronic.parse("January 1st 2090 at 10:31 pm") do
-        allow(liquidsoap_requests).to receive(:skip).with(radio).and_return(nil)
-        expect(liquidsoap_requests).to receive(:skip).with(radio)
+        allow(liquidsoap_requests_class).to receive(:new).with(radio.id).and_return(liquidsoap)
+        expect(liquidsoap).to receive(:skip)
         expect_any_instance_of(ScheduledShow).to receive(:queue_playlist!)
         ScheduleMonitor.perform radio, Time.now
         expect(radio.current_show_playing.to_i).to eq scheduled_show.id.to_i
@@ -37,15 +38,15 @@ describe ScheduleMonitor do
           start_at: Chronic.parse("January 1st 2090 at 11:00 pm"), end_at: Chronic.parse("January 1st 2090 at 11:30 pm"),
           dj: dj
         Timecop.travel Chronic.parse("January 1st 2090 at 10:31 pm") do
-          allow(liquidsoap_requests).to receive(:skip).with(radio).and_return(nil)
-          expect(liquidsoap_requests).to receive(:skip).with(radio)
+          allow(liquidsoap_requests_class).to receive(:new).with(radio.id).and_return(liquidsoap)
+          expect(liquidsoap).to receive(:skip)
           #expect_any_instance_of(ScheduledShow).to receive(:queue_playlist!)
           ScheduleMonitor.perform radio, Time.now
           expect(radio.current_show_playing.to_i).to eq scheduled_show1.id.to_i
         end
         Timecop.travel Chronic.parse("January 1st 2090 at 11:01 pm") do
-          allow(liquidsoap_requests).to receive(:skip).with(radio).and_return(nil)
-          expect(liquidsoap_requests).not_to receive(:skip).with(radio)
+          allow(liquidsoap_requests_class).to receive(:new).with(radio.id).and_return(liquidsoap)
+          expect(liquidsoap).not_to receive(:skip)
           #expect_any_instance_of(ScheduledShow).to receive(:queue_playlist!)
           ScheduleMonitor.perform radio, Time.now
           expect(radio.current_show_playing.to_i).to eq scheduled_show2.id.to_i
@@ -60,15 +61,15 @@ describe ScheduleMonitor do
           start_at: Chronic.parse("January 1st 2090 at 11:00 pm"), end_at: Chronic.parse("January 1st 2090 at 11:30 pm"),
           dj: dj
         Timecop.travel Chronic.parse("January 1st 2090 at 10:31 pm") do
-          allow(liquidsoap_requests).to receive(:skip).with(radio).and_return(nil)
-          expect(liquidsoap_requests).to receive(:skip).with(radio)
+          allow(liquidsoap_requests_class).to receive(:new).with(radio.id).and_return(liquidsoap)
+          expect(liquidsoap).to receive(:skip)
           #expect_any_instance_of(ScheduledShow).to receive(:queue_playlist!)
           ScheduleMonitor.perform radio, Time.now
           expect(radio.current_show_playing.to_i).to eq scheduled_show1.id.to_i
         end
         Timecop.travel Chronic.parse("January 1st 2090 at 11:01 pm") do
-          allow(liquidsoap_requests).to receive(:skip).with(radio).and_return(nil)
-          expect(liquidsoap_requests).to receive(:skip).with(radio)
+          allow(liquidsoap_requests_class).to receive(:new).with(radio.id).and_return(liquidsoap)
+          expect(liquidsoap).to receive(:skip)
           #expect_any_instance_of(ScheduledShow).to receive(:queue_playlist!)
           ScheduleMonitor.perform radio, Time.now
           expect(radio.current_show_playing.to_i).to eq scheduled_show2.id.to_i
@@ -83,14 +84,14 @@ describe ScheduleMonitor do
         start_at: Chronic.parse("January 1st 2090 at 10:30 pm"), end_at: Chronic.parse("January 1st 2090 at 11:00 pm"),
         dj: dj
       Timecop.travel Chronic.parse("January 1st 2090 at 10:31 pm") do
-        allow(liquidsoap_requests).to receive(:skip).with(radio).and_return(nil)
-        expect(liquidsoap_requests).to receive(:skip).with(radio)
+        allow(liquidsoap_requests_class).to receive(:new).with(radio.id).and_return(liquidsoap)
+        expect(liquidsoap).to receive(:skip)
         expect_any_instance_of(ScheduledShow).to receive(:queue_playlist!)
         ScheduleMonitor.perform radio, Time.now
       end
       Timecop.travel Chronic.parse("January 1st 2090 at 10:45 pm") do
-        allow(liquidsoap_requests).to receive(:skip).with(radio).and_return(nil)
-        expect(liquidsoap_requests).not_to receive(:skip).with(radio)
+        allow(liquidsoap_requests_class).to receive(:new).with(radio.id).and_return(liquidsoap)
+        expect(liquidsoap).not_to receive(:skip)
         expect_any_instance_of(ScheduledShow).not_to receive(:queue_playlist!)
         ScheduleMonitor.perform radio, Time.now
       end


### PR DESCRIPTION
The streampusher.com/liquidsoap_requests page was crashing, I think it was creating too many connections to liquidsoap at once. This should fix it.