### PR TITLE
fix scheduler queuing default playlist

### DIFF
--- a/app/controllers/scheduled_shows_controller.rb
+++ b/app/controllers/scheduled_shows_controller.rb
@@ -134,7 +134,7 @@ class ScheduledShowsController < ApplicationController
     params.require(:scheduled_show).permit(:title, :radio_id, :start_at,
                                            :end_at, :description, :image, :update_all_recurrences,
                                            :recurring_interval, :playlist_id, :time_zone,
-                                           :start, :end, :is_guest, :guest,
+                                           :start, :end, :is_guest, :guest, :is_live,
                                            scheduled_show_performers_attributes: [:id, :user_id])
   end
 end

--- a/app/models/scheduled_show.rb
+++ b/app/models/scheduled_show.rb
@@ -69,7 +69,7 @@ class ScheduledShow < ActiveRecord::Base
   #
   def queue_playlist!
     liquidsoap = LiquidsoapRequests.new radio.id
-    if self.playlist.present?
+    if self.playlist.present? && self.playlist.redis_length > 0
       while self.playlist.redis_length > 0
         track_id = self.playlist.pop_next_track
         if track_id.present?
@@ -79,6 +79,8 @@ class ScheduledShow < ActiveRecord::Base
           liquidsoap.add_to_queue track.url
         end
       end
+    else
+      puts "tried to queue #{self.inspect}'s playlist, but playlist empty in redis!"
     end
   end
 

--- a/app/services/schedule_monitor.rb
+++ b/app/services/schedule_monitor.rb
@@ -11,19 +11,21 @@ class ScheduleMonitor
     if !current_scheduled_show_in_db  # no show scheduled now, clear it
       puts "no current show, clearing redis"
       radio.set_current_show_playing nil
-    # hacks
-    elsif current_scheduled_show_in_db.is_live? || current_scheduled_show_in_db.playlist.id == radio.default_playlist.id
-      puts "shouldn't queue a playlist for a live show!"
     elsif current_scheduled_show_in_db && (current_scheduled_show_in_db.id != current_playing_show_in_redis.try(:id).to_i) # its not the next show yet, but next_track will set it
       # add next show's track (or entire playlist?) to queue
-      puts "adding to queue"
-      current_scheduled_show_in_db.queue_playlist!
-      puts "received queue_playlist!"
-      # if previous show is set to no_cue_out, or previous show is blank, time to skip!
-      if current_playing_show_in_redis.blank? || !current_playing_show_in_redis.playlist.no_cue_out? # check cue out of previous show
-        puts "skipping"
-        liquidsoap = LiquidsoapRequests.new radio.id
-        liquidsoap.skip
+      unless current_scheduled_show_in_db.is_live? || current_scheduled_show_in_db.playlist.id == radio.default_playlist.id
+        puts "adding to queue"
+        current_scheduled_show_in_db.queue_playlist!
+        puts "received queue_playlist!"
+        # if previous show is set to no_cue_out, or previous show is blank, time to skip!
+        if current_playing_show_in_redis.blank? || !current_playing_show_in_redis.playlist.no_cue_out? # check cue out of previous show
+          puts "skipping"
+          liquidsoap = LiquidsoapRequests.new radio.id
+          liquidsoap.skip
+        end
+      else
+        # hacks
+        puts "shouldn't queue a playlist for a live show!"
       end
       # current_scheduled_show_in_db and redis should sync
       radio.set_current_show_playing current_scheduled_show_in_db.id

--- a/app/services/schedule_monitor.rb
+++ b/app/services/schedule_monitor.rb
@@ -11,6 +11,9 @@ class ScheduleMonitor
     if !current_scheduled_show_in_db  # no show scheduled now, clear it
       puts "no current show, clearing redis"
       radio.set_current_show_playing nil
+    # hacks
+    elsif current_scheduled_show_in_db.is_live? || current_scheduled_show_in_db.playlist.id == radio.default_playlist.id
+      puts "shouldn't queue a playlist for a live show!"
     elsif current_scheduled_show_in_db && (current_scheduled_show_in_db.id != current_playing_show_in_redis.try(:id).to_i) # its not the next show yet, but next_track will set it
       # add next show's track (or entire playlist?) to queue
       puts "adding to queue"

--- a/app/views/scheduled_shows/_form.html.erb
+++ b/app/views/scheduled_shows/_form.html.erb
@@ -6,6 +6,7 @@
   <%= f.simple_fields_for :scheduled_show_performers do |g| %>
     <%= g.input :user_id, collection: @current_radio.djs, label_method: :username, value_method: :id, label: 'Host' %>
   <% end %>
+  <%= f.input :is_live, label: "Live Broadcast" %>
   <%= f.input :is_guest, label: "Guest Host" %>
   <%= f.input :guest %>
   <div class="note">

--- a/db/migrate/20210606145058_add_is_live_to_scheduled_show.rb
+++ b/db/migrate/20210606145058_add_is_live_to_scheduled_show.rb
@@ -1,0 +1,5 @@
+class AddIsLiveToScheduledShow < ActiveRecord::Migration[5.0]
+  def change
+    add_column :scheduled_shows, :is_live, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210528014036) do
+ActiveRecord::Schema.define(version: 20210606145058) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -255,6 +255,7 @@ ActiveRecord::Schema.define(version: 20210528014036) do
     t.string   "slug"
     t.boolean  "is_guest",              default: false, null: false
     t.string   "guest",                 default: "",    null: false
+    t.boolean  "is_live",               default: false, null: false
     t.index ["dj_id"], name: "index_scheduled_shows_on_dj_id", using: :btree
     t.index ["playlist_id"], name: "index_scheduled_shows_on_playlist_id", using: :btree
     t.index ["radio_id"], name: "index_scheduled_shows_on_radio_id", using: :btree

--- a/spec/services/schedule_monitor_spec.rb
+++ b/spec/services/schedule_monitor_spec.rb
@@ -106,11 +106,12 @@ describe ScheduleMonitor do
         expect(liquidsoap).not_to receive(:skip)
         expect_any_instance_of(ScheduledShow).not_to receive(:queue_playlist!)
         ScheduleMonitor.perform radio, Time.now
+        expect(radio.current_show_playing.to_i).to eq scheduled_show1.id.to_i
       end
     end
   end
   describe "if current show's playlist is the default one" do
-    it "does nothing" do
+    it "does nothing except set current_playing_show_in_redis" do
       scheduled_show1 = FactoryBot.create :scheduled_show, playlist: playlist, radio: radio,
         start_at: Chronic.parse("January 1st 2090 at 10:30 pm"), end_at: Chronic.parse("January 1st 2090 at 11:00 pm"),
         dj: dj, is_live: true
@@ -120,6 +121,7 @@ describe ScheduleMonitor do
         expect(liquidsoap).not_to receive(:skip)
         expect_any_instance_of(ScheduledShow).not_to receive(:queue_playlist!)
         ScheduleMonitor.perform radio, Time.now
+        expect(radio.current_show_playing.to_i).to eq scheduled_show1.id.to_i
       end
     end
   end

--- a/spec/services/schedule_monitor_spec.rb
+++ b/spec/services/schedule_monitor_spec.rb
@@ -97,4 +97,10 @@ describe ScheduleMonitor do
       end
     end
   end
+  describe "if current show is_live" do
+    it "does nothing"
+  end
+  describe "if current show's playlist is the default one" do
+    it "does nothing"
+  end
 end

--- a/spec/services/schedule_monitor_spec.rb
+++ b/spec/services/schedule_monitor_spec.rb
@@ -78,7 +78,6 @@ describe ScheduleMonitor do
     end
   end
   describe "when the current show is already playing at its proper time" do
-    # how do i test that it does nothing???
     it "does nothing" do
       scheduled_show1 = FactoryBot.create :scheduled_show, playlist: playlist, radio: radio,
         start_at: Chronic.parse("January 1st 2090 at 10:30 pm"), end_at: Chronic.parse("January 1st 2090 at 11:00 pm"),
@@ -98,9 +97,30 @@ describe ScheduleMonitor do
     end
   end
   describe "if current show is_live" do
-    it "does nothing"
+    it "does nothing" do
+      scheduled_show1 = FactoryBot.create :scheduled_show, playlist: playlist, radio: radio,
+        start_at: Chronic.parse("January 1st 2090 at 10:30 pm"), end_at: Chronic.parse("January 1st 2090 at 11:00 pm"),
+        dj: dj, is_live: true
+      Timecop.travel Chronic.parse("January 1st 2090 at 10:32 pm") do
+        allow(liquidsoap_requests_class).to receive(:new).with(radio.id).and_return(liquidsoap)
+        expect(liquidsoap).not_to receive(:skip)
+        expect_any_instance_of(ScheduledShow).not_to receive(:queue_playlist!)
+        ScheduleMonitor.perform radio, Time.now
+      end
+    end
   end
   describe "if current show's playlist is the default one" do
-    it "does nothing"
+    it "does nothing" do
+      scheduled_show1 = FactoryBot.create :scheduled_show, playlist: playlist, radio: radio,
+        start_at: Chronic.parse("January 1st 2090 at 10:30 pm"), end_at: Chronic.parse("January 1st 2090 at 11:00 pm"),
+        dj: dj, is_live: true
+      radio.update default_playlist: playlist
+      Timecop.travel Chronic.parse("January 1st 2090 at 10:32 pm") do
+        allow(liquidsoap_requests_class).to receive(:new).with(radio.id).and_return(liquidsoap)
+        expect(liquidsoap).not_to receive(:skip)
+        expect_any_instance_of(ScheduledShow).not_to receive(:queue_playlist!)
+        ScheduleMonitor.perform radio, Time.now
+      end
+    end
   end
 end


### PR DESCRIPTION
Indicate whether a show is going to be live or playing a playlist.

closes https://github.com/datafruits/streampusher-api/issues/105