### PR TITLE
fix: changed VCR to match on request method

### DIFF
--- a/spec/models/track_spec.rb
+++ b/spec/models/track_spec.rb
@@ -37,7 +37,7 @@ describe Track do
 
   describe "scheduled show" do
     it "pulls tags and artwork from scheduled show if not set" do
-      VCR.use_cassette(RSpec.current_example.metadata[:full_description].to_s) do
+      VCR.use_cassette(RSpec.current_example.metadata[:full_description].to_s, match_requests_on: [:method, :host, :s3_image_matcher]) do
         start_at = Chronic.parse("today at 1:15 pm").utc
         end_at = Chronic.parse("today at 3:15 pm").utc
         radio = Radio.create name: 'datafruits'

--- a/spec/support/vcr_config.rb
+++ b/spec/support/vcr_config.rb
@@ -47,4 +47,13 @@ VCR.configure do |config|
     uri2.query = nil
     uri1.to_s.gsub(/\/\d{3}/,"") == uri2.to_s.gsub(/\/\d{3}/,"")
   end
+
+  config.register_request_matcher :s3_image_matcher do |request1, request2|
+    uri1 = URI(request1.uri)
+    uri2 = URI(request2.uri)
+
+    uri_regex = /^\/artworks\/(original|thumb)\/_hey-hey-[0-9]{8}__[A-z0-9]{64}\.png/
+  
+    uri1.host == uri2.host && uri_regex.match?(uri1.path) && uri_regex.match?(uri2.path)
+  end
 end

--- a/spec/support/vcr_config.rb
+++ b/spec/support/vcr_config.rb
@@ -52,7 +52,7 @@ VCR.configure do |config|
     uri1 = URI(request1.uri)
     uri2 = URI(request2.uri)
 
-    uri_regex = /^\/artworks\/(original|thumb)\/_hey-hey-[0-9]{8}__[A-z0-9]{64}\.png/
+    uri_regex = /^\/artworks\/(original|thumb)\/_hey-hey-[0-9]+__[A-z0-9]+\.png/
   
     uri1.host == uri2.host && uri_regex.match?(uri1.path) && uri_regex.match?(uri2.path)
   end

--- a/spec/support/vcr_config.rb
+++ b/spec/support/vcr_config.rb
@@ -54,6 +54,6 @@ VCR.configure do |config|
 
     uri_regex = /^\/artworks\/(original|thumb)\/_hey-hey-[0-9]+__[A-z0-9]+\.png/
   
-    uri1.host == uri2.host && uri_regex.match?(uri1.path) && uri_regex.match?(uri2.path)
+    uri_regex.match?(uri1.path) && uri_regex.match?(uri2.path)
   end
 end


### PR DESCRIPTION
it seems that since file names are randomly generated

VCR cannot consistently match and replay the request based on the URL + Method

Since the cassette file contains only 1 request (for a file upload) it
is a safe change to make VCR match on request method only for this test case

Fixes https://github.com/datafruits/streampusher-api/issues/113