### PR TITLE
fix intermittent spec failure in spec/models/playlist_spec.rb

### DIFF
--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -14,7 +14,7 @@ class Playlist < ActiveRecord::Base
   after_save :set_default_playlist
   after_save :persist_to_redis
   after_touch :persist_to_redis
-  before_destroy :set_another_playlist_to_default
+  before_destroy :set_most_recently_updated_playlist_to_default
 
   default_scope { order(updated_at: :desc) }
 
@@ -60,7 +60,7 @@ class Playlist < ActiveRecord::Base
     end
   end
 
-  def set_another_playlist_to_default
+  def set_most_recently_updated_playlist_to_default
     if default?
       self.radio.update default_playlist_id: self.radio.playlists.where.not(id: id).first.id
     end

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -21,12 +21,11 @@ RSpec.describe Playlist, :type => :model do
     expect(playlist.tracks.include?(track)).to eq false
   end
 
-  it "sets another playlist to default if default is being destroyed" do
+  it "reset default to most recently updated playlist if default is destroyed" do
     radio  = FactoryBot.create :radio
-    playlist_1 = FactoryBot.create :playlist, radio: radio
-    playlist_2 = FactoryBot.create :playlist, radio: radio
+    playlist_1 = FactoryBot.create :playlist, radio: radio, updated_at: 2.days.ago
+    playlist_2 = FactoryBot.create :playlist, radio: radio, updated_at: 1.day.ago
     radio.default_playlist.destroy
-    radio.reload
-    expect(radio.default_playlist).to eq playlist_2
+    expect(radio.reload.default_playlist).to eq playlist_2
   end
 end

--- a/spec/models/scheduled_show_spec.rb
+++ b/spec/models/scheduled_show_spec.rb
@@ -96,6 +96,10 @@ RSpec.describe ScheduledShow, :type => :model do
       Timecop.freeze Time.local(2015)
     end
 
+    after do
+      Timecop.return
+    end
+
     it "saves recurring shows if recurring is true" do
       start_at = Chronic.parse("today at 1:15 pm").utc
       end_at = Chronic.parse("today at 3:15 pm").utc


### PR DESCRIPTION
- basically the issue is being caused because when rspec is run on CI/CD all the Playlist records sometimes have created_at and updated_at set to exactly "2015-01-01 00:00:00"
<img width="854" alt="Screen Shot 2021-07-09 at 12 37 25 PM" src="https://user-images.githubusercontent.com/9378055/125150955-7c7cd880-e0f8-11eb-889b-2c86cc3d54c1.png">

- this happened because a random test, `spec/models/scheduled_show_spec.rb`, called `Timecop.freeze Time.local(2015)`, but never called `Timecop.return`.  this means that every subsequent spec ran with time frozen at exactly new year's 2015 - and this this may be responsible for multiple intermittent spec failures that depend on timestamps

- in the case of` playlist_spec.rb`, when the existing default Playlist is destroyed, the model first applies a `default_scope` of `order(updated_at: :desc)` that sorts by updated date, and then chooses the Playlist that has the latest `updated_at` to become the new default thru `radio.playlists.where.not(id: id).first.id`.  if all the playlists have the same timestamp, then the ActiveRecord query will return a random order each time the test is run, thus causing the intermittent failure

- why does this happen on CI/CD but not locally, when you run that one test? well it only happens specifically when scheduled_show_spec.rb precedes playlist_spec.rb during rspec's execution.  so if you're just running playlist_spec in isolation you'll never see it.  rspec often jumbles up the order of tests so it's likely that sometimes playlist_spec runs before scheduled_show_spec and vice versa at random.  and hence the intermittent nature of the failure on CI/CD.  i

- I've done a few things:
(1) I've added a `Timecop.return` to the spec that called `Timecop.freeze` so that time is not frozen for all subsequent specs
(2) renamed the `after_destroy` callback method in the Playlist model to be more explicit about what it's doing to avoid confusion - it's not just setting any old playlist as the new default; rather , it's setting the most recently updated, as defined by the updated_at timestamp, as default.
(3) since the spec is really about picking whether playlist_1 or playlist_2 is the new default, I explicitly set their updated_at to be 1 day apart.  this is not, strictly speaking necessary for the spec to pass, but it makes it clear that the deciding factor for which playlist becomes default is in fact the updated_at date