### PR TITLE
try to fix payout_fruit_ticket_track_plays_worker_spec

### DIFF
--- a/spec/fixtures/vcr_cassettes/PayoutFruitTicketTrackPlaysWorker_pays_out_royalties_for_track_plays.yml
+++ b/spec/fixtures/vcr_cassettes/PayoutFruitTicketTrackPlaysWorker_pays_out_royalties_for_track_plays.yml
@@ -1,0 +1,89 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://streampushertest.s3.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.160.0 ruby/2.7.2 x86_64-linux aws-sdk-s3/1.114.0
+      X-Amz-Date:
+      - 20230416T175316Z
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<S3_KEY>/20230416/us-east-1/s3/aws4_request, SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=861241e5bfb336b519c912b32058f57ccd897fe6fb53f550b3698a2ec73836c9
+      Content-Length:
+      - '0'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amz-Id-2:
+      - WJLdTS8cCxKFU/dwdh4dhBbnX6JqXx8f66fTHAC3VQ12vql4MYHlvtRClzo9CAuEDOjV7DhT26g=
+      X-Amz-Request-Id:
+      - BMN6TBE4A0QM2VQ1
+      Date:
+      - Sun, 16 Apr 2023 17:53:19 GMT
+      Location:
+      - "/streampushertest"
+      Server:
+      - AmazonS3
+      Content-Length:
+      - '0'
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Sun, 16 Apr 2023 17:53:17 GMT
+- request:
+    method: get
+    uri: https://streampushertest.s3.amazonaws.com/spec/fixtures/the_cowbell.mp3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby3/3.160.0 ruby/2.7.2 x86_64-linux aws-sdk-s3/1.114.0
+      X-Amz-Date:
+      - 20230416T175317Z
+      X-Amz-Content-Sha256:
+      - e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=<S3_KEY>/20230416/us-east-1/s3/aws4_request, SignedHeaders=host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=d6c237de8a6fb651a8aff7e2917594e643f7ddde24a3ca59590e0e00d43903b1
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      X-Amz-Request-Id:
+      - BMNAAW35JT5V79WR
+      X-Amz-Id-2:
+      - tQVejepbkivnC03prkkV1K+1+HZ4yJEAPqWuzoV2MuKT6TlkWiU+EfGB8Es7JqVqsigpKR19d54=
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Sun, 16 Apr 2023 17:53:17 GMT
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>spec/fixtures/the_cowbell.mp3</Key><RequestId>BMNAAW35JT5V79WR</RequestId><HostId>tQVejepbkivnC03prkkV1K+1+HZ4yJEAPqWuzoV2MuKT6TlkWiU+EfGB8Es7JqVqsigpKR19d54=</HostId></Error>
+  recorded_at: Sun, 16 Apr 2023 17:53:17 GMT
+recorded_with: VCR 6.1.0

--- a/spec/workers/payout_fruit_ticket_track_plays_worker_spec.rb
+++ b/spec/workers/payout_fruit_ticket_track_plays_worker_spec.rb
@@ -13,17 +13,19 @@ describe PayoutFruitTicketTrackPlaysWorker do
     redis.flushall
   end
   it "pays out royalties for track plays" do
-    radio = FactoryBot.create :radio
-    user = FactoryBot.create :user, fruit_ticket_balance: 0
-    playlist = FactoryBot.create :playlist, radio: radio
-    scheduled_show = FactoryBot.create :scheduled_show, dj: user, start_at: 2.days.from_now, end_at: 3.days.from_now, playlist: playlist, radio: radio
-    track = FactoryBot.create :track, scheduled_show: scheduled_show, radio: radio
-    redis.hset("datafruits:track_plays", track.id, 3)
-    PayoutFruitTicketTrackPlaysWorker.perform_now
-    user.reload
-    expect(user.fruit_ticket_balance).to eq 3
+    VCR.use_cassette(RSpec.current_example.metadata[:full_description].to_s) do
+      radio = FactoryBot.create :radio
+      user = FactoryBot.create :user, fruit_ticket_balance: 0
+      playlist = FactoryBot.create :playlist, radio: radio
+      scheduled_show = FactoryBot.create :scheduled_show, dj: user, start_at: 2.days.from_now, end_at: 3.days.from_now, playlist: playlist, radio: radio
+      track = FactoryBot.create :track, radio: radio
+      redis.hset("datafruits:track_plays", track.id, 3)
+      PayoutFruitTicketTrackPlaysWorker.perform_now
+      user.reload
+      expect(user.fruit_ticket_balance).to eq 3
 
-    fruit_ticket_transaction = FruitTicketTransaction.last
-    expect(fruit_ticket_transaction.source_id).to eq track.id
+      fruit_ticket_transaction = FruitTicketTransaction.last
+      expect(fruit_ticket_transaction.source_id).to eq track.id
+    end
   end
 end


### PR DESCRIPTION
Trying to fix this, keeps getting an error:
```
  1) PayoutFruitTicketTrackPlaysWorker pays out royalties for track plays
     Failure/Error: track = FactoryBot.create :track, radio: radio

     Aws::S3::Errors::NoSuchKey:
       The specified key does not exist.
     # ./vendor/bundle/ruby/2.7.0/gems/aws-sdk-core-3.160.0/lib/seahorse/client/plugins/raise_respo
nse_errors.rb:17:in `call'
     # ./vendor/bundle/ruby/2.7.0/gems/aws-sdk-s3-1.114.0/lib/aws-sdk-s3/plugins/skip_whole_multipa
rt_get_checksums.rb:18:in `call'
     # ./vendor/bundle/ruby/2.7.0/gems/aws-sdk-s3-1.114.0/lib/aws-sdk-s3/plugins/sse_cpk.rb:24:in `
call'
     # ./vendor/bundle/ruby/2.7.0/gems/aws-sdk-s3-1.114.0/lib/aws-sdk-s3/plugins/dualstack.rb:27:in
 `call'
     # ./vendor/bundle/ruby/2.7.0/gems/aws-sdk-s3-1.114.0/lib/aws-sdk-s3/plugins/accelerate.rb:56:i
n `call'
     # ./vendor/bundle/ruby/2.7.0/gems/aws-sdk-core-3.160.0/lib/aws-sdk-core/plugins/checksum_algor
```
I believe it's trying to upload and image for the associated scheduled show, but I'm not sure why it's saying 'The specified key does not exist'.