### PR TITLE
Fix wiki pages index returning 404 when no pages exist

### DIFF
--- a/app/controllers/api/wiki_pages_controller.rb
+++ b/app/controllers/api/wiki_pages_controller.rb
@@ -8,11 +8,7 @@ class Api::WikiPagesController < ApplicationController
     else
       @wiki_pages = WikiPage.all.order("updated_at DESC")
     end
-    if @wiki_pages.count > 0
-      render json: @wiki_pages
-    else
-      render json: { "error": "not found" } , status: 404
-    end
+    render json: @wiki_pages
   end
 
   def show


### PR DESCRIPTION
The `index` action was returning a 404 with an error body when there were no wiki pages. It should return an empty array instead, letting clients handle the empty state gracefully.