### PR TITLE
enable rack mini profiler on podcast endpoints

### DIFF
--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -5,6 +5,9 @@ class PodcastsController < ApplicationController
 
   load_and_authorize_resource except: [:show]
   before_action :current_radio_required, only: [:show]
+  before_action do
+        Rack::MiniProfiler.authorize_request
+  end
   serialization_scope :serializer_scope
 
   def index


### PR DESCRIPTION
Trying to figure out why the podcasts/datafruits.xml takes so long to render 🙃 